### PR TITLE
Resolves #1 add show time option

### DIFF
--- a/MetaWorldNPT/JavaScripts/depend/god-mod/GodModParam.ts
+++ b/MetaWorldNPT/JavaScripts/depend/god-mod/GodModParam.ts
@@ -81,6 +81,13 @@ export interface GodCommandParamOption<P = string> {
     validator?: (DataValidator<P> | DataValidatorWithReason<P>)[];
 
     label?: string;
+
+    /**
+     * 结果显示时长. ms
+     * @desc 仅在自定义 string 类型结果时生效.
+     * @desc 否则使用默认显示时长. 2e3 ms
+     */
+    resultShowTime?: number;
 }
 
 //#region Validator Preset

--- a/MetaWorldNPT/JavaScripts/depend/god-mod/GodModService.ts
+++ b/MetaWorldNPT/JavaScripts/depend/god-mod/GodModService.ts
@@ -114,7 +114,8 @@ export default class GodModService extends Singleton<GodModService>() {
                 (event) => {
                     const e = event as GodModCommandRunResult;
                     if (this._currentFrontFocus === e.label) {
-                        this.showUiResult(e.result);
+                        this.showUiResult(e.result,
+                            this._commands.get(e.label)?.paramOption?.resultShowTime);
                     }
                 },
             );
@@ -539,11 +540,12 @@ export default class GodModService extends Singleton<GodModService>() {
     /**
      * 显示执行反馈结果。
      * @param {boolean} result
+     * @param {number} showTime 显示时间. ms
      * @private
      */
-    private showUiResult(result: boolean | string) {
+    private showUiResult(result: boolean | string, showTime?: number) {
         if (typeof result === "string") {
-            this._view?.showTips(result);
+            this._view?.showTips(result, showTime);
         } else {
             if (result) this._view?.showSuccess();
             else this._view?.showError();

--- a/MetaWorldNPT/JavaScripts/depend/god-mod/package.json
+++ b/MetaWorldNPT/JavaScripts/depend/god-mod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mw-god-mod",
-  "version": "36.1.2",
+  "version": "36.1.3",
   "author": "LviatYi",
   "description": "GodMod Credit By G.S.C.",
   "license": "MIT",

--- a/MetaWorldNPT/JavaScripts/depend/god-mod/ui/GodModPanel.ts
+++ b/MetaWorldNPT/JavaScripts/depend/god-mod/ui/GodModPanel.ts
@@ -101,6 +101,8 @@ export class GodModPanel extends Component {
 
     private _enterFloatDist: number;
 
+    private _currentTipShowTime: number;
+
     private get btnMovePointerLocation(): mw.Vector2 {
         if (Gtk.useMouse) return mw.getMousePositionOnPlatform();
         else return this._currentTouchBtnMoveLocation;
@@ -397,7 +399,7 @@ export class GodModPanel extends Component {
     protected renderAnimHandler: (dt: number) => void = dt => {
         if (this._txtInfo.renderOpacity > 0) {
             const d = Date.now() - this._lastShowTipsTime;
-            if (d > GodModPanel.TipsShownTime) {
+            if (d > this._currentTipShowTime) {
                 this._txtInfo.renderOpacity = Math.max(0,
                     this._txtInfo.renderOpacity - dt / (GodModPanel.TipsFadeTime / 1000));
             }
@@ -672,15 +674,16 @@ export class GodModPanel extends Component {
         }
     }
 
-    private innerShowTips(text: string, color?: string) {
+    private innerShowTips(text: string, color?: string, showTime?: number) {
         this._txtInfo.setFontColorByHex(ColorUtil.colorHexWithAlpha(color ?? Color.Blue, 1));
         this._txtInfo.text = text;
         this._lastShowTipsTime = Date.now();
         this._txtInfo.renderOpacity = 1;
+        this._currentTipShowTime = showTime ?? GodModPanel.TipsShownTime;
     }
 
-    public showTips(text: string) {
-        this.innerShowTips(text, Color.Green);
+    public showTips(text: string, showTime?: number) {
+        this.innerShowTips(text, Color.Green, showTime);
     }
 
     private showWarning(text: string) {


### PR DESCRIPTION
add show time option

(cherry picked from commit efef7edf93d70d66e540d1a5b0abd95640b18766)

# Background 背景

当 GodMod CMD 返回 string 时，GodMod 将在面板上展示该内容。当返回信息过长时，默认的显示时长可能不足以允许用户
进行观察。

## Feature 功能

该提交提供了一个新功能，用于在 GodMod CMD 返回 string 时，客制化显示时间。

## Key Changes 核心变化

在 addGMCommand 中的 paramOption 参数，添加了 `resultShowTime` 可选字段。

```TypeScript
/**
 * 结果显示时长. ms
 * @desc 仅在自定义 string 类型结果时生效.
 * @desc 否则使用默认显示时长. 2e3 ms
 */
resultShowTime?: number;
```

## Why 必要性

该 PR 旨在提供更好的交互体验，属于优化但不是必要的。

## Test 测试

时间问题及复杂度考量，未进行测试。

## PR 类型

- [ ] fix 修复 Bug
- [x] feature 增加新功能
- [ ] style 风格调整
- [ ] refactor 重构
- [ ] build 依赖或构建改变
- [ ] doc 文档内容更新
- [ ] etc 请描述：

## 检查列表

- [x] 我的代码遵循这个项目的代码风格。
- [x] 我已经进行自我 Review。
- [x] 我尽可能注释了我的代码，特别是在难以理解的领域。
- [x] 我尽可能保持了向下兼容性，如果没有，我在 Key Changes 节指明了迁移步骤。
- [x] 我对相关改变的影响做了相应的修改。
